### PR TITLE
Add transitioning animated value to Transitioner state.

### DIFF
--- a/src/views/StackView/StackViewLayout.js
+++ b/src/views/StackView/StackViewLayout.js
@@ -192,6 +192,11 @@ class StackViewLayout extends React.Component {
   }
 
   _reset(resetToIndex, duration) {
+    const {
+      transitionProps: { transitioning },
+    } = this.props;
+    transitioning.setValue(0);
+
     if (Platform.OS === 'ios' && supportsImprovedSpringAnimation()) {
       Animated.spring(this.props.transitionProps.position, {
         toValue: resetToIndex,
@@ -260,7 +265,7 @@ class StackViewLayout extends React.Component {
     },
     onPanResponderGrant: () => {
       const {
-        transitionProps: { navigation, position, scene },
+        transitionProps: { navigation, position, scene, transitioning },
       } = this.props;
       const { index } = navigation.state;
 
@@ -268,6 +273,7 @@ class StackViewLayout extends React.Component {
         return false;
       }
 
+      transitioning.setValue(-1);
       position.stopAnimation(value => {
         this._isResponding = true;
         this._gestureStartValue = value;
@@ -449,7 +455,7 @@ class StackViewLayout extends React.Component {
       );
     }
     const {
-      transitionProps: { scene, scenes },
+      transitionProps: { scene, scenes, progress, transitioning },
       mode,
     } = this.props;
     const { options } = scene.descriptor;


### PR DESCRIPTION
## Motivation

We'd like to be able to use Screen native components from https://github.com/kmagiera/react-native-screens as an alternative backend for StackLayout. My `<ScreenStack>` component requires `transitioning` as one of the props to orchestrate screen transition in native. This change does not affect other parts of the library as so I think it would be the best way to move forward with migration towards using _Screens_.

The idea behind transitioning prop is that it indicates the state of transition in the following way:
 - if we are animating back (e.g. pop or back swipe) the value is -1
 - if we are animating new screen in the value is 1
 - otherwise the value is 0 (stationary state, no ongoing transitions)

## Test plan

Run example app and see that navigation between screens is not affected. The newly added prop is not being used anywhere and so it will only be possible to test it with my follow up diff that adds dependency on _Screens_.
You may want to check the branch that has all the changes here: https://github.com/react-navigation/react-navigation-stack/tree/screens

## Changelog

 - Add new transitioning prop to Transitioner state