### PR TITLE
Use ScreenContainer and Screen components in stack - currently they fallback to RN's View

### DIFF
--- a/src/views/StackView/StackViewCard.js
+++ b/src/views/StackView/StackViewCard.js
@@ -1,21 +1,36 @@
 import React from 'react';
-import { Animated, StyleSheet } from 'react-native';
+import { StyleSheet } from 'react-native';
+import { Screen } from './screens';
 import createPointerEventsContainer from './createPointerEventsContainer';
+
+const EPS = 1e-5;
 
 /**
  * Component that renders the scene as card for the <StackView />.
  */
 class Card extends React.Component {
   render() {
-    const { children, pointerEvents, style } = this.props;
+    const {
+      children,
+      pointerEvents,
+      style,
+      position,
+      scene: { index },
+    } = this.props;
+    const active = position.interpolate({
+      inputRange: [index, index + 1 - EPS, index + 1],
+      outputRange: [1, 1, 0],
+      extrapolate: 'clamp',
+    });
     return (
-      <Animated.View
+      <Screen
         pointerEvents={pointerEvents}
         ref={this.props.onComponentRef}
         style={[styles.main, style]}
+        active={active}
       >
         {children}
-      </Animated.View>
+      </Screen>
     );
   }
 }

--- a/src/views/StackView/StackViewLayout.js
+++ b/src/views/StackView/StackViewLayout.js
@@ -21,6 +21,7 @@ import {
 
 import Card from './StackViewCard';
 import Header from '../Header/Header';
+import { ScreenContainer } from './screens';
 
 import TransitionConfigs from './StackViewTransitionConfigs';
 import { supportsImprovedSpringAnimation } from '../../utils/ReactNativeFeatures';
@@ -469,9 +470,9 @@ class StackViewLayout extends React.Component {
 
     return (
       <View {...handlers} style={containerStyle}>
-        <View style={styles.scenes}>
+        <ScreenContainer style={styles.scenes}>
           {scenes.map(s => this._renderCard(s))}
-        </View>
+        </ScreenContainer>
         {floatingHeader}
       </View>
     );

--- a/src/views/StackView/screens.js
+++ b/src/views/StackView/screens.js
@@ -1,0 +1,6 @@
+import { Animated, View } from 'react-native';
+
+const ScreenContainer = View;
+const Screen = Animated.View;
+
+export { ScreenContainer, Screen };


### PR DESCRIPTION
## Motivation

This PR introduces an abstraction for base components to be used as building blocks for navigation stack. We introduce `ScreenContainer` and `Screen` component. First representing a container in which `Screen`s can be rendered and is used in `StackViewLayout` where we render all the cards. Then `Screen` is used as a top level component for each `Card` and is directly rendered inside `ScreenContainer`.

On top of that each `Screen` component gets added `active` property which is interpolated such that the value is `1` when card is on top of the stack or second to last but we are transitioning, or `0` when there is no point for that card to be visible.

In the future this will allow for alternative native components to be used instead of Views that use platform specific abstraction to provide proper lifecycle hooks to the native views in their hierarchies.

## Test plan

Run test app, see adding new items to the stack works as expected