### PR TITLE
Allow Explicitly Setting Gesture Direction and Show Proper Transition Direction

### DIFF
--- a/src/views/StackView/StackView.js
+++ b/src/views/StackView/StackView.js
@@ -51,15 +51,15 @@ class StackView extends React.Component {
       transitionProps.index === prevTransitionProps.index
         ? this.gestureDirection
         : transitionProps.scene.descriptor.options.gestureDirection;
-        å
+
     return {
       ...TransitionConfigs.getTransitionConfig(
         this.props.navigationConfig.transitionConfig,
         transitionProps,
         prevTransitionProps,
         this.props.navigationConfig.mode === 'modal' ||
-        this.gestureDirection === 'down' ||
-        this.gestureDirection === 'up'
+          this.gestureDirection === 'down' ||
+          this.gestureDirection === 'up'
       ).transitionSpec,
       useNativeDriver: !!NativeAnimatedModule,
     };

--- a/src/views/StackView/StackView.js
+++ b/src/views/StackView/StackView.js
@@ -46,12 +46,20 @@ class StackView extends React.Component {
   }
 
   _configureTransition = (transitionProps, prevTransitionProps) => {
+    this.gestureDirection = this.gestureDirection || null;
+    this.gestureDirection =
+      transitionProps.index === prevTransitionProps.index
+        ? this.gestureDirection
+        : transitionProps.scene.descriptor.options.gestureDirection;
+        å
     return {
       ...TransitionConfigs.getTransitionConfig(
         this.props.navigationConfig.transitionConfig,
         transitionProps,
         prevTransitionProps,
-        this.props.navigationConfig.mode === 'modal'
+        this.props.navigationConfig.mode === 'modal' ||
+        this.gestureDirection === 'down' ||
+        this.gestureDirection === 'up'
       ).transitionSpec,
       useNativeDriver: !!NativeAnimatedModule,
     };

--- a/src/views/StackView/StackViewLayout.js
+++ b/src/views/StackView/StackViewLayout.js
@@ -277,13 +277,19 @@ class StackViewLayout extends React.Component {
         mode,
       } = this.props;
       const { index } = navigation.state;
-      const isVertical = mode === 'modal';
       const { options } = scene.descriptor;
       const gestureDirection = options.gestureDirection;
 
+      const isVertical =
+        mode === 'modal' ||
+        gestureDirection === 'up' ||
+        gestureDirection === 'down';
+
       const gestureDirectionInverted =
         typeof gestureDirection === 'string'
-          ? gestureDirection === 'inverted'
+          ? gestureDirection === 'inverted' ||
+            gestureDirection === 'left' ||
+            gestureDirection === 'up'
           : I18nManager.isRTL;
 
       if (index !== scene.index) {
@@ -334,9 +340,13 @@ class StackViewLayout extends React.Component {
         mode,
       } = this.props;
       const { index } = navigation.state;
-      const isVertical = mode === 'modal';
       const { options } = scene.descriptor;
       const gestureDirection = options.gestureDirection;
+
+      const isVertical =
+        mode === 'modal' ||
+        gestureDirection === 'up' ||
+        gestureDirection === 'down';
 
       const gestureDirectionInverted =
         typeof gestureDirection === 'string'
@@ -366,9 +376,13 @@ class StackViewLayout extends React.Component {
         mode,
       } = this.props;
       const { index } = navigation.state;
-      const isVertical = mode === 'modal';
       const { options } = scene.descriptor;
       const gestureDirection = options.gestureDirection;
+
+      const isVertical =
+        mode === 'modal' ||
+        gestureDirection === 'up' ||
+        gestureDirection === 'down';
 
       const gestureDirectionInverted =
         typeof gestureDirection === 'string'
@@ -578,13 +592,20 @@ class StackViewLayout extends React.Component {
   }
 
   _getTransitionConfig = () => {
-    const isModal = this.props.mode === 'modal';
+    const { scene } = this.props.transitionProps;
+    const { options } = scene.descriptor;
+    const gestureDirection = options.gestureDirection;
+
+    const isVertical =
+      mode === 'modal' ||
+      gestureDirection === 'up' ||
+      gestureDirection === 'down';
 
     return TransitionConfigs.getTransitionConfig(
       this.props.transitionConfig,
       this.props.transitionProps,
       this.props.lastTransitionProps,
-      isModal
+      isVertical
     );
   };
 

--- a/src/views/StackView/StackViewLayout.js
+++ b/src/views/StackView/StackViewLayout.js
@@ -597,7 +597,7 @@ class StackViewLayout extends React.Component {
     const gestureDirection = options.gestureDirection;
 
     const isVertical =
-      mode === 'modal' ||
+      this.props.mode === 'modal' ||
       gestureDirection === 'up' ||
       gestureDirection === 'down';
 

--- a/src/views/StackView/StackViewTransitionConfigs.js
+++ b/src/views/StackView/StackViewTransitionConfigs.js
@@ -63,7 +63,7 @@ const FadeOutToBottomAndroid = {
 function defaultTransitionConfig(
   transitionProps,
   prevTransitionProps,
-  isModal
+  isVertical
 ) {
   if (Platform.OS === 'android') {
     // Use the default Android animation no matter if the screen is a modal.
@@ -78,7 +78,7 @@ function defaultTransitionConfig(
     return FadeInFromBottomAndroid;
   }
   // iOS and other platforms
-  if (isModal) {
+  if (isVertical) {
     return ModalSlideFromBottomIOS;
   }
   return SlideFromRightIOS;
@@ -88,17 +88,17 @@ function getTransitionConfig(
   transitionConfigurer,
   transitionProps,
   prevTransitionProps,
-  isModal
+  isVertical
 ) {
   const defaultConfig = defaultTransitionConfig(
     transitionProps,
     prevTransitionProps,
-    isModal
+    isVertical
   );
   if (transitionConfigurer) {
     return {
       ...defaultConfig,
-      ...transitionConfigurer(transitionProps, prevTransitionProps, isModal),
+      ...transitionConfigurer(transitionProps, prevTransitionProps, isVertical),
     };
   }
   return defaultConfig;


### PR DESCRIPTION
Motivation:
I have a project with a custom transitionConfig that has some app screens entering from the bottom of the device screen, and others entering from the right of the device screen. I wanted to allow users to use swipe gestures with these screens in a logical direction based on the way the screens entered.

This is an adaptation of a previous PR for the react-navigation library, which can be found here: https://github.com/react-navigation/react-navigation/pull/3868