### PR TITLE
Remove accessible tag from card

### DIFF
--- a/src/views/StackView/StackViewCard.js
+++ b/src/views/StackView/StackViewCard.js
@@ -9,7 +9,6 @@ function getAccessibilityProps(isActive) {
   if (Platform.OS === 'ios') {
     return {
       accessibilityElementsHidden: !isActive,
-      accessible: isActive,
     };
   } else if (Platform.OS === 'android') {
     return {


### PR DESCRIPTION
The react native `accessible` tag groups elements into a single selectable element for VoiceOver users. By setting the entire card `Screen` as `accessible={true}`, all interaction is disabled for VoiceOver users since the entire screen behaves as a single element.