### PR TITLE
Remove accessible props from nav buttons children

### DIFF
--- a/src/views/Header/HeaderBackButton.js
+++ b/src/views/Header/HeaderBackButton.js
@@ -93,6 +93,7 @@ class HeaderBackButton extends React.PureComponent {
 
     return (
       <Text
+        accessible={false}
         onLayout={this._onTextLayout}
         style={[styles.title, !!tintColor && { color: tintColor }, titleStyle]}
         numberOfLines={1}
@@ -107,6 +108,7 @@ class HeaderBackButton extends React.PureComponent {
 
     let button = (
       <TouchableItem
+        accessible={false}
         accessibilityComponentType="button"
         accessibilityLabel={title}
         accessibilityTraits="button"

--- a/src/views/Header/HeaderTitle.js
+++ b/src/views/Header/HeaderTitle.js
@@ -9,6 +9,7 @@ const HeaderTitle = ({ style, ...rest }) => (
     {...rest}
     style={[styles.title, style]}
     accessibilityTraits="header"
+    accessible={false}
   />
 );
 


### PR DESCRIPTION
The (potentially 3) nav elements including Title, Back/Left and Right buttons should be the ones that are accessible for interaction by VoiceOver users. All of their children elements should then not be accessible in order for proper VoiceOver use. Currently, because the children are accessible, the user gets stuck when they click just on the text or on one of the intermediate view components.