### PR TITLE
Fix black screen during the pop animation when using rn-screens

### DIFF
--- a/src/views/StackView/StackViewCard.js
+++ b/src/views/StackView/StackViewCard.js
@@ -34,7 +34,7 @@ class Card extends React.Component {
 
     const active = position.interpolate({
       inputRange: [index, index + 1 - EPS, index + 1],
-      outputRange: [1, 1, 0],
+      outputRange: [1, 1, isActive ? 1 : 0],
       extrapolate: 'clamp',
     });
 

--- a/src/views/StackView/StackViewCard.js
+++ b/src/views/StackView/StackViewCard.js
@@ -32,9 +32,11 @@ class Card extends React.Component {
       scene: { index, isActive },
     } = this.props;
 
-    const active = position.interpolate({
+    const active = isActive
+      ? 1
+      : position.interpolate({
       inputRange: [index, index + 1 - EPS, index + 1],
-      outputRange: [1, 1, isActive ? 1 : 0],
+      outputRange: [1, 1, 0],
       extrapolate: 'clamp',
     });
 


### PR DESCRIPTION
When poping a screen off the stack the indices change and the active interpolation no longer works properly. This causes a black screen for the screen under the screen that is being pop'ed. Not sure if there is a better way to adapt the interpolation but an easy fix is to make sure the active screen is never interpolates down to 0.

Tested in an app where I found the bug.