### PR TITLE
Make sure header back button is accessible

### DIFF
--- a/src/views/Header/HeaderBackButton.js
+++ b/src/views/Header/HeaderBackButton.js
@@ -93,7 +93,7 @@ class HeaderBackButton extends React.PureComponent {
 
     return (
       <Text
-        accessible={false}
+        accessible={true}
         onLayout={this._onTextLayout}
         style={[styles.title, !!tintColor && { color: tintColor }, titleStyle]}
         numberOfLines={1}

--- a/src/views/Header/HeaderBackButton.js
+++ b/src/views/Header/HeaderBackButton.js
@@ -93,7 +93,7 @@ class HeaderBackButton extends React.PureComponent {
 
     return (
       <Text
-        accessible={true}
+        accessible={false}
         onLayout={this._onTextLayout}
         style={[styles.title, !!tintColor && { color: tintColor }, titleStyle]}
         numberOfLines={1}
@@ -108,7 +108,7 @@ class HeaderBackButton extends React.PureComponent {
 
     let button = (
       <TouchableItem
-        accessible={false}
+        accessible={true}
         accessibilityComponentType="button"
         accessibilityLabel={title}
         accessibilityTraits="button"


### PR DESCRIPTION
We are using accessibility identifiers to click the buttons. It looks like we set accessibility label here... so setting `accessible` to `false` has probably been a mistake.