### PR TITLE
Added window dimensions for iPhone XS Max and iPhone XR

### DIFF
--- a/src/views/StackView/StackViewLayout.js
+++ b/src/views/StackView/StackViewLayout.js
@@ -28,15 +28,17 @@ import { supportsImprovedSpringAnimation } from '../../utils/ReactNativeFeatures
 
 const emptyFunction = () => {};
 
+const IPHONE_XS_HEIGHT = 812; // iPhone X and XS
+const IPHONE_XR_HEIGHT = 896; // iPhone XR and XS Max
 const { width: WINDOW_WIDTH, height: WINDOW_HEIGHT } = Dimensions.get('window');
 const IS_IPHONE_X =
   Platform.OS === 'ios' &&
   !Platform.isPad &&
   !Platform.isTVOS &&
-  (WINDOW_HEIGHT === 812 ||
-    WINDOW_WIDTH === 812 ||
-    WINDOW_HEIGHT === 896 ||
-    WINDOW_WIDTH === 896);
+  (WINDOW_HEIGHT === IPHONE_XS_HEIGHT ||
+    WINDOW_WIDTH === IPHONE_XS_HEIGHT ||
+    WINDOW_HEIGHT === IPHONE_XR_HEIGHT ||
+    WINDOW_WIDTH === IPHONE_XR_HEIGHT);
 
 const EaseInOut = Easing.inOut(Easing.ease);
 

--- a/src/views/StackView/StackViewLayout.js
+++ b/src/views/StackView/StackViewLayout.js
@@ -33,7 +33,10 @@ const IS_IPHONE_X =
   Platform.OS === 'ios' &&
   !Platform.isPad &&
   !Platform.isTVOS &&
-  (WINDOW_HEIGHT === 812 || WINDOW_WIDTH === 812);
+  (WINDOW_HEIGHT === 812 ||
+    WINDOW_WIDTH === 812 ||
+    WINDOW_HEIGHT === 896 ||
+    WINDOW_WIDTH === 896);
 
 const EaseInOut = Easing.inOut(Easing.ease);
 


### PR DESCRIPTION
## Motivation

The floating header is not displayed correctly on iPhone XS Max and iPhone XR due to the height being too small. It is displayed correctly however on iPhone X and XS thanks to the `IS_IPHONE_X` boolean being set to true.

<img width="1168" alt="iphone xs max - layout issue 2" src="https://user-images.githubusercontent.com/1689105/45593361-45831a00-b942-11e8-8e9b-81265134c1ec.png">

## Description of Change

Updated `IS_IPHONE_X` boolean to now be true for both iPhone XS Max and iPhone XR, in addition to the currently supported iPhone X and iPhone XS.

iPhone X and XS in portrait have a height dimension of `812`, while iPhone XS Max and iPhone XR  have a height dimension of `896`. This means apps using this library, will scale appropriately on both the iPhone XS Max and iPhone XR with this change.

<img width="1202" alt="iphone x dimensions" src="https://user-images.githubusercontent.com/1689105/45531330-8d703880-b7ac-11e8-8e22-f907a248d185.png">
