### PR TITLE
Export all files from npm package

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.5.1",
   "description": "Stack navigator component for React Navigation",
   "main": "dist/index.js",
+  "react-native": "src/index.js",
   "scripts": {
     "test": "jest",
     "lint": "eslint .",

--- a/package.json
+++ b/package.json
@@ -3,6 +3,12 @@
   "version": "0.5.1",
   "description": "Stack navigator component for React Navigation",
   "main": "dist/index.js",
+  "files": [
+    "dist",
+    "src",
+    "LICENSE.md",
+    "README.md"
+   ],
   "react-native": "src/index.js",
   "scripts": {
     "test": "jest",

--- a/package.json
+++ b/package.json
@@ -4,8 +4,8 @@
   "description": "Stack navigator component for React Navigation",
   "main": "dist/index.js",
   "files": [
-    "dist",
-    "src",
+    "dist/",
+    "src/",
     "LICENSE.md",
     "README.md"
    ],

--- a/package.json
+++ b/package.json
@@ -3,9 +3,6 @@
   "version": "0.5.1",
   "description": "Stack navigator component for React Navigation",
   "main": "dist/index.js",
-  "files": [
-    "dist/"
-  ],
   "scripts": {
     "test": "jest",
     "lint": "eslint .",


### PR DESCRIPTION
This allows all files to come with the npm package, and points Metro to the source code so that it can provide source maps for consumption in react-native apps.

