### PR TITLE
Stack nav completion on mount

### DIFF
--- a/src/views/StackView/StackView.js
+++ b/src/views/StackView/StackView.js
@@ -45,6 +45,17 @@ class StackView extends React.Component {
     );
   }
 
+  componentDidMount() {
+    const { navigation } = this.props;
+    if (navigation.state.isTransitioning) {
+      navigation.dispatch(
+        StackActions.completeTransition({
+          key: navigation.state.key,
+        })
+      );
+    }
+  }
+
   _configureTransition = (transitionProps, prevTransitionProps) => {
     return {
       ...TransitionConfigs.getTransitionConfig(


### PR DESCRIPTION
StackView is responsible for calling the navigation completion action when `state.isTransitioning` is set. This fix handles that case when the stack is first mounting.

This had caused the following issue when observing the events.. because isTransitioning was never switched to false, didFocus never gets called: https://github.com/react-navigation/react-navigation/issues/4867