### PR TITLE
Allow headerLeft components to control their own rendering

### DIFF
--- a/src/views/Header/Header.js
+++ b/src/views/Header/Header.js
@@ -217,6 +217,7 @@ class Header extends React.PureComponent {
         titleStyle={options.headerBackTitleStyle}
         layoutPreset={this.props.layoutPreset}
         width={width}
+        scene={props.scene}
       />
     );
   };


### PR DESCRIPTION
Within the `_renderLeftComponent` there is logic around wether or not the component should be rendered. This allows the `headerLeft: Component` to make these decisions within it's own rendering.

I don't believe there is any downside to passing these props through.

This is required because of the code introduced here: https://github.com/react-navigation/react-navigation/issues/4608 which alters the behaviour of `headerLeft` from v1 -> v2.