### PR TITLE
change accessibilityLabel for HeaderBackButton - Fix iOS voiceover

### DIFF
--- a/src/views/Header/HeaderBackButton.js
+++ b/src/views/Header/HeaderBackButton.js
@@ -110,7 +110,7 @@ class HeaderBackButton extends React.PureComponent {
       <TouchableItem
         accessible
         accessibilityComponentType="button"
-        accessibilityLabel={title}
+        accessibilityLabel={title ? `${title}, back` : 'Go back'}
         accessibilityTraits="button"
         testID="header-back"
         delayPressIn={0}


### PR DESCRIPTION
Hey! This is my pull request on this task:
https://github.com/react-navigation/react-navigation/issues/5028

I changed the accessibilityLabel prop value to:
 ```accessibilityLabel={title ? `${title}, back` : 'Go back'}``` so now if previous screen title is "Home" it reads as "Home, back, button"
I also spotted the situation when someone does not provide `title` in `navigationOptions`.
Previously it reads as "undefined, button" and now: "Go back, button"