### PR TITLE
Don't call onTransitionStart if unspecified

### DIFF
--- a/src/views/Transitioner.js
+++ b/src/views/Transitioner.js
@@ -101,12 +101,14 @@ class Transitioner extends React.Component {
 
     if (!this._transitionProps.navigation.state.isTransitioning) {
       this.setState(nextState, async () => {
-        const result = nextProps.onTransitionStart(
-          this._transitionProps,
-          this._prevTransitionProps
-        );
-        if (result instanceof Promise) {
-          await result;
+        if (nextProps.onTransitionStart) {
+          const result = nextProps.onTransitionStart(
+            this._transitionProps,
+            this._prevTransitionProps
+          );
+          if (result instanceof Promise) {
+            await result;
+          }
         }
         progress.setValue(1);
         position.setValue(toValue);


### PR DESCRIPTION
This call should be gated, same as the call on line 157. This wasn't noticed before because it's in a `!isTransitioning` special case. I noticed it because I'm using Redux integration in my store: it gets triggered when `redux-persist` rehydrates my Redux store, which triggers `Transitioner` without specifying `isTransitioning`.