### PR TITLE
Fixed the accessibility label issue in WebDriver.io / Appium

### DIFF
--- a/src/views/Header/HeaderBackButton.js
+++ b/src/views/Header/HeaderBackButton.js
@@ -105,7 +105,7 @@ class HeaderBackButton extends React.PureComponent {
 
   render() {
     const { onPress, pressColorAndroid, title } = this.props;
-    const accessibilityLabel = title ? title : 'header-back';
+    const accessibilityLabel = title ? title : 'Back';
 
     let button = (
       <TouchableItem

--- a/src/views/Header/HeaderBackButton.js
+++ b/src/views/Header/HeaderBackButton.js
@@ -105,12 +105,13 @@ class HeaderBackButton extends React.PureComponent {
 
   render() {
     const { onPress, pressColorAndroid, title } = this.props;
+    const accessibilityLabel = title ? title : 'header-back';
 
     let button = (
       <TouchableItem
         accessible
         accessibilityComponentType="button"
-        accessibilityLabel={title}
+        accessibilityLabel={accessibilityLabel}
         accessibilityTraits="button"
         testID="header-back"
         delayPressIn={0}


### PR DESCRIPTION
<img width="1495" alt="screen shot 2018-10-09 at 11 33 00" src="https://user-images.githubusercontent.com/580631/46663884-2da45c00-cbb7-11e8-8f27-7e5f33515252.png">

If your design doesn't support title on the react navigation header back button and if you try to access the `Header back button` using webdriver.io it throws an exception as `test ID` support is still being flaky on webdriver.io/appium and the tests are failing. 

So need a support for default accessibility label value to make the webdriver.io/appium tests robust.

When I tested it by making the default title on the react navigation header and we get the default accessibility label by default which is the `title` in this regard makes the webdriver.io tests passing consistently. 

Unfortunately, I can not have the title due to design limitaitons. So need to create this pull request to make the webdriver.io tests passing with the default accessibility label value.

P.S:

This issue is the continuation to the header back button accessible issue solved here

https://github.com/react-navigation/react-navigation-stack/pull/21