### PR TITLE
Rethink queued transitions

### DIFF
--- a/example/src/SimpleStack.js
+++ b/example/src/SimpleStack.js
@@ -9,11 +9,24 @@ const Buttons = withNavigation(props => (
       title="Go to Details"
       onPress={() => props.navigation.navigate('Details')}
     />
+    <Button title="Go and then go to details quick" onPress={() => {
+      let routeName = props.navigation.state.routeName;
+      props.navigation.pop();
+      setTimeout(() => {
+        props.navigation.navigate('Details');
+      }, 100);
+    }} />
     <Button
       title="Go to Headerless"
       onPress={() => props.navigation.navigate('Headerless')}
     />
     <Button title="Go back" onPress={() => props.navigation.goBack()} />
+    <Button title="Go back quick" onPress={() => {
+      props.navigation.pop();
+      setTimeout(() => {
+        props.navigation.pop();
+      }, 100);
+    }} />
     <Button
       title="Go back to all examples"
       onPress={() => props.navigation.navigate('Home')}
@@ -25,6 +38,14 @@ class ListScreen extends React.Component {
   static navigationOptions = {
     title: 'List',
   };
+
+  componentDidMount() {
+    console.log('ListScreen didMount');
+  }
+
+  componentWillUnmount() {
+    console.log('ListScreen willUnmount');
+  }
 
   render() {
     return (
@@ -51,6 +72,14 @@ class DetailsScreen extends React.Component {
       horizontal: Dimensions.get('window').width,
     },
   };
+
+  componentDidMount() {
+    console.log('DetailsScreen didMount');
+  }
+
+  componentWillUnmount() {
+    console.log('DetailsScreen willUnmount');
+  }
 
   render() {
     return (
@@ -80,6 +109,14 @@ class HeaderlessScreen extends React.Component {
   static navigationOptions = {
     header: null,
   };
+
+  componentDidMount() {
+    console.log('HeaderlessScreen didMount');
+  }
+
+  componentWillUnmount() {
+    console.log('HeaderlessScreen willUnmount');
+  }
 
   render() {
     return (

--- a/example/src/SimpleStack.js
+++ b/example/src/SimpleStack.js
@@ -9,24 +9,29 @@ const Buttons = withNavigation(props => (
       title="Go to Details"
       onPress={() => props.navigation.navigate('Details')}
     />
-    <Button title="Go and then go to details quick" onPress={() => {
-      let routeName = props.navigation.state.routeName;
-      props.navigation.pop();
-      setTimeout(() => {
-        props.navigation.navigate('Details');
-      }, 100);
-    }} />
+    <Button
+      title="Go and then go to details quick"
+      onPress={() => {
+        props.navigation.pop();
+        setTimeout(() => {
+          props.navigation.navigate('Details');
+        }, 100);
+      }}
+    />
     <Button
       title="Go to Headerless"
       onPress={() => props.navigation.navigate('Headerless')}
     />
     <Button title="Go back" onPress={() => props.navigation.goBack()} />
-    <Button title="Go back quick" onPress={() => {
-      props.navigation.pop();
-      setTimeout(() => {
+    <Button
+      title="Go back quick"
+      onPress={() => {
         props.navigation.pop();
-      }, 100);
-    }} />
+        setTimeout(() => {
+          props.navigation.pop();
+        }, 100);
+      }}
+    />
     <Button
       title="Go back to all examples"
       onPress={() => props.navigation.navigate('Home')}

--- a/src/views/Transitioner.js
+++ b/src/views/Transitioner.js
@@ -336,26 +336,6 @@ function filterStale(scenes) {
   return filtered;
 }
 
-function filterNotInState(scenes, state) {
-  let activeKeys = state.routes.map(r => r.key);
-  let filtered = scenes.filter(scene =>
-    activeKeys.includes(scene.descriptor.key)
-  );
-
-  if (__DEV__ && DEBUG) {
-    console.log({
-      activeKeys,
-      filtered: filtered.map(s => s.descriptor.key),
-      scenes: scenes.map(s => s.descriptor.key),
-    });
-  }
-
-  if (filtered.length === scenes.length) {
-    return scenes;
-  }
-  return filtered;
-}
-
 function isSceneActive(scene) {
   return scene.isActive;
 }


### PR DESCRIPTION
The problem with queued transitions currently is that *we compute the next scenes at the time of queuing* and *the current scenes are an input to that*, but the scenes change after the transition is completed and before the queued transition is fired! For example, when you pop a route the scene is still in the transitioner scenes state until once the transition is complete, so if you pop it and then before the transition is over you push a new route, then when the queued transition fires it will mount that scene again. That leads to issues like this: https://github.com/react-navigation/react-navigation/issues/5152

What I propose we do in this PR is that instead of computing scenes when props change before queueing the transition, we just store away the props at that point (that is, this.props in componentWillReceiveProps, not nextProps) in time in the queue and when the time comes to clear the queue we determine scenes from the scenes at that point in time, the stored away props and the current props (if no other change happened, this would be on the same props as nextProps at the time it was queued).