### PR TITLE
Fix issue where header height wouldn't be taken into account for transparentCard

### DIFF
--- a/src/views/StackView/StackViewLayout.js
+++ b/src/views/StackView/StackViewLayout.js
@@ -822,9 +822,9 @@ class StackViewLayout extends React.Component {
     const { options } = scene.descriptor;
     const hasHeader = options.header !== null;
     const headerMode = this._getHeaderMode();
-    let paddingTop = 0;
+    let top = 0;
     if (hasHeader && headerMode === 'float' && !options.headerTransparent) {
-      paddingTop = this.state.floatingHeaderHeight;
+      top = this.state.floatingHeaderHeight;
     }
 
     return (
@@ -835,7 +835,7 @@ class StackViewLayout extends React.Component {
         realPosition={this.props.transitionProps.position}
         animatedStyle={style}
         transparent={this.props.transparentCard}
-        style={[{ paddingTop }, this.props.cardStyle]}
+        style={[{ top }, this.props.cardStyle]}
         scene={scene}
       >
         {this._renderInnerScene(scene)}


### PR DESCRIPTION
Potential fix for #65 - changes `paddingTop` to `top` so header height will still be taken into account when `transparentCard: true`