### PR TITLE
Fix transparent header height measurement (Fix #60)

### DIFF
--- a/src/views/Header/Header.js
+++ b/src/views/Header/Header.js
@@ -660,12 +660,7 @@ const styles = StyleSheet.create({
     ...platformContainerStyles,
   },
   transparentContainer: {
-    position: 'absolute',
-    top: 0,
-    left: 0,
-    right: 0,
     ...platformContainerStyles,
-    borderBottomWidth: 0,
     borderBottomColor: 'transparent',
     elevation: 0,
   },


### PR DESCRIPTION
Hello!

Header is positioned absolute in Layout layer already. Making container absolute prevents `StackViewLayout` to measure header height causing _jumpy header_ while switching screens.

The demo is available in #60

Thanks.