### PR TITLE
Prevent previous screen fade out on push/pop on Android

### DIFF
--- a/src/views/StackView/StackViewStyleInterpolator.js
+++ b/src/views/StackView/StackViewStyleInterpolator.js
@@ -125,8 +125,8 @@ function forFadeFromBottomAndroid(props) {
   const { first, last } = interpolate;
   const index = scene.index;
   const opacity = position.interpolate({
-    inputRange: [first, first + 0.5, first + 0.9, index, last],
-    outputRange: [0, 0.25, 0.7, 1, 0],
+    inputRange: [first, first + 0.5, first + 0.9, index, last - 1e-5, last],
+    outputRange: [0, 0.25, 0.7, 1, 1, 0],
     extrapolate: 'clamp',
   });
 
@@ -160,7 +160,7 @@ function forFadeToBottomAndroid(props) {
 
   const opacity = position.interpolate({
     inputRange,
-    outputRange: [0, 1, 0],
+    outputRange: [0, 1, 1],
     extrapolate: 'clamp',
   });
 


### PR DESCRIPTION
When animating new screen in on Android we used to, by default, fade out the previously displayed screen. Then when going back to it it would fade in from 0 to 1. This seem to be not how the default screen animation on Android performs and has also an additional consequence that the app background is partially visible during screen transition. It is because during transition both the transitioning in and transitioning out views are semi transparent.

### Motivation

Make Android default screen transition alike platform default one and also fix the problem when app background can be seen during transition.

### CAUTION

This is potentially breaking change as it changes the default animation configuration on Android.

### Notes

Note that there is another issue related to opacity not blending correctly when stack animation in ongoing. This causes the card background "flashes" and can be mitigated by setting `cardStyle: { backgroundColor: 'YOUR-SCREEN_BG' }` in navigation config. When using react-native-screens the correct blending is applied for the duration of animation and hence resolves this problem completely.

### Test plan

1) Run the following code on Android -> https://snack.expo.io/@kzzzf/rn-nav-flash-android-v3
2) When opening next screen or closing the screen note that there is a moment when white background flashes
3) With this change in this should no longer appear

To illustrate the change I changed app background to green to make it easier to see. Here is what changes:

OLD TRANSITION IN:
![without-fadein](https://user-images.githubusercontent.com/726445/50221425-5c983480-0395-11e9-96ee-6890ccfe2cdb.png)

OLD TRANSITION OUT:
![without-fadeout](https://user-images.githubusercontent.com/726445/50221412-52763600-0395-11e9-95d5-54c6fa8f079e.png)

NEW TRANSITION IN:
![with-fadein](https://user-images.githubusercontent.com/726445/50221320-04f9c900-0395-11e9-8c99-20deeba2277e.png)

NEW TRANSITION OUT:
![with-fadeout](https://user-images.githubusercontent.com/726445/50221319-02976f00-0395-11e9-8685-6bf8d1a32191.png)



