### PR TITLE
fix: Transitioner await onTransitionStart

### DIFF
--- a/src/views/Transitioner.js
+++ b/src/views/Transitioner.js
@@ -169,7 +169,7 @@ class Transitioner extends React.Component {
             this._prevTransitionProps
           );
 
-          // why do we bother awaiting the result here?
+          // Wait for the onTransitionStart to resolve if needed.
           if (result instanceof Promise) {
             await result;
           }

--- a/src/views/Transitioner.js
+++ b/src/views/Transitioner.js
@@ -174,39 +174,39 @@ class Transitioner extends React.Component {
             await result;
           }
         }
-      });
 
-      // get the transition spec.
-      const transitionUserSpec = nextProps.configureTransition
-        ? nextProps.configureTransition(
+        // get the transition spec.
+        const transitionUserSpec = nextProps.configureTransition
+          ? nextProps.configureTransition(
             this._transitionProps,
             this._prevTransitionProps
           )
-        : null;
+          : null;
 
-      const transitionSpec = {
-        ...DefaultTransitionSpec,
-        ...transitionUserSpec,
-      };
+        const transitionSpec = {
+          ...DefaultTransitionSpec,
+          ...transitionUserSpec,
+        };
 
-      const { timing } = transitionSpec;
-      delete transitionSpec.timing;
+        const { timing } = transitionSpec;
+        delete transitionSpec.timing;
 
-      // if swiped back, indexHasChanged == true && positionHasChanged == false
-      const positionHasChanged = position.__getValue() !== toValue;
-      if (indexHasChanged && positionHasChanged) {
-        timing(position, {
-          ...transitionSpec,
-          toValue: nextProps.navigation.state.index,
-        }).start(() => {
-          // In case the animation is immediately interrupted for some reason,
-          // we move this to the next frame so that onTransitionStart can fire
-          // first (https://github.com/react-navigation/react-navigation/issues/5247)
-          requestAnimationFrame(this._onTransitionEnd);
-        });
-      } else {
-        this._onTransitionEnd();
-      }
+        // if swiped back, indexHasChanged == true && positionHasChanged == false
+        const positionHasChanged = position.__getValue() !== toValue;
+        if (indexHasChanged && positionHasChanged) {
+          timing(position, {
+            ...transitionSpec,
+            toValue: nextProps.navigation.state.index,
+          }).start(() => {
+            // In case the animation is immediately interrupted for some reason,
+            // we move this to the next frame so that onTransitionStart can fire
+            // first (https://github.com/react-navigation/react-navigation/issues/5247)
+            requestAnimationFrame(this._onTransitionEnd);
+          });
+        } else {
+          this._onTransitionEnd();
+        }
+      });
     }
   }
 


### PR DESCRIPTION
The idea was there, but the scope was wrong. Now, we actually wait for the onTransitionStart to complete its work before moving on instead of awaiting in a context with zero follow up procedures.

**Update:** I did actually test this against a working navigator. Render gets called, but no interpolation happens yet because the transition doesn't start. This is the intended and also documented behaviour.