### PR TITLE
iOS Accessibility - add headerBackAllowFontScaling option

### DIFF
--- a/src/views/Header/Header.js
+++ b/src/views/Header/Header.js
@@ -214,6 +214,7 @@ class Header extends React.PureComponent {
         title={backButtonTitle}
         truncatedTitle={truncatedBackButtonTitle}
         backTitleVisible={this.props.backTitleVisible}
+        allowFontScaling={options.headerBackAllowFontScaling}
         titleStyle={options.headerBackTitleStyle}
         layoutPreset={this.props.layoutPreset}
         width={width}

--- a/src/views/Header/HeaderBackButton.js
+++ b/src/views/Header/HeaderBackButton.js
@@ -92,7 +92,7 @@ class HeaderBackButton extends React.PureComponent {
         onLayout={this._onTextLayout}
         style={[styles.title, !!tintColor && { color: tintColor }, titleStyle]}
         numberOfLines={1}
-        allowFontScaling={allowFontScaling}
+        allowFontScaling={!!allowFontScaling}
       >
         {this._getTitleText()}
       </Text>

--- a/src/views/Header/HeaderBackButton.js
+++ b/src/views/Header/HeaderBackButton.js
@@ -79,7 +79,7 @@ class HeaderBackButton extends React.PureComponent {
   };
 
   _maybeRenderTitle() {
-    const { backTitleVisible, titleStyle, tintColor } = this.props;
+    const { allowFontScaling, backTitleVisible, titleStyle, tintColor } = this.props;
     let backTitleText = this._getTitleText();
 
     if (!backTitleVisible || backTitleText === null) {
@@ -92,7 +92,7 @@ class HeaderBackButton extends React.PureComponent {
         onLayout={this._onTextLayout}
         style={[styles.title, !!tintColor && { color: tintColor }, titleStyle]}
         numberOfLines={1}
-        allowFontScaling={false}
+        allowFontScaling={allowFontScaling}
       >
         {this._getTitleText()}
       </Text>

--- a/src/views/Header/HeaderBackButton.js
+++ b/src/views/Header/HeaderBackButton.js
@@ -92,6 +92,7 @@ class HeaderBackButton extends React.PureComponent {
         onLayout={this._onTextLayout}
         style={[styles.title, !!tintColor && { color: tintColor }, titleStyle]}
         numberOfLines={1}
+        allowFontScaling={false}
       >
         {this._getTitleText()}
       </Text>


### PR DESCRIPTION
On iOS, apps can support larger font sizes for accessibility.

![screenshot 2019-02-19 11 48 40](https://user-images.githubusercontent.com/9510/53043653-cdafa300-343d-11e9-8f32-177f1984f1b9.png)

React-native supports this out-of-the-box, which is awesome. But the navigation bar turns into kind of a UX disaster:

![screenshot 2019-02-19 11 53 05](https://user-images.githubusercontent.com/9510/53043667-d3a58400-343d-11e9-8f1f-37139010e7f3.png)

Looking at default iOS apps provided by Apple, they often don't scale the navigation bar, which makes sense given the limited real-estate, so it's OK to turn that off. Like for example, here's what the settings app looks like with font-sizes maxed out.

![screenshot 2019-02-19 12 11 39](https://user-images.githubusercontent.com/9510/53044329-8a563400-343f-11e9-9fa8-e088e093d720.png)

And react-navigation provides an option for turning off font scaling for the title, getting us closer to a usable navigation bar:

```
navigationOptions: {
        headerTitleAllowFontScaling: false,
}
```
![screenshot 2019-02-19 11 55 35](https://user-images.githubusercontent.com/9510/53044375-a8bc2f80-343f-11e9-9503-4ef4dfcac202.png)

But it doesn't have an option for the back button, which this PR addresses.

```
navigationOptions: {
        headerBackAllowFontScaling: false, // new!
        headerTitleAllowFontScaling: false,
}
```
![screenshot 2019-02-19 13 20 59](https://user-images.githubusercontent.com/9510/53048314-4cf6a400-3449-11e9-9d59-11b81caf9c4b.png)

I'm excited about getting this change into react-navigation. If there's anything I can do to help that process please let me know.