### PR TITLE
[Web] More web support

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -18,7 +18,7 @@ module.exports = {
         require('./views/assets/back-icon.png'),
         require('./views/assets/back-icon-mask.png'),
       ],
-      android: [require('./views/assets/back-icon.png')],
+      default: [require('./views/assets/back-icon.png')],
     });
   },
   get Header() {

--- a/src/navigators/createStackNavigator.js
+++ b/src/navigators/createStackNavigator.js
@@ -1,5 +1,6 @@
 import { StackRouter, createNavigator } from '@react-navigation/core';
 import { createKeyboardAwareNavigator } from '@react-navigation/native';
+import { Platform } from 'react-native';
 import StackView from '../views/StackView/StackView';
 
 function createStackNavigator(routeConfigMap, stackConfig = {}) {
@@ -7,7 +8,7 @@ function createStackNavigator(routeConfigMap, stackConfig = {}) {
 
   // Create a navigator with StackView as the view
   let Navigator = createNavigator(StackView, router, stackConfig);
-  if (!stackConfig.disableKeyboardHandling) {
+  if (!stackConfig.disableKeyboardHandling && Platform.OS !== 'web') {
     Navigator = createKeyboardAwareNavigator(Navigator, stackConfig);
   }
 

--- a/src/views/Header/Header.js
+++ b/src/views/Header/Header.js
@@ -641,17 +641,16 @@ function warnIfHeaderStyleDefined(value, styleProp) {
   }
 }
 
-let platformContainerStyles;
-if (Platform.OS === 'ios') {
-  platformContainerStyles = {
+const platformContainerStyles = Platform.select({
+  android: {
+    elevation: 4,
+  },
+  ios: {
     borderBottomWidth: StyleSheet.hairlineWidth,
     borderBottomColor: '#A7A7AA',
-  };
-} else {
-  platformContainerStyles = {
-    elevation: 4,
-  };
-}
+  },
+  default: {},
+});
 
 const DEFAULT_BACKGROUND_COLOR = '#FFF';
 

--- a/src/views/Header/HeaderBackButton.js
+++ b/src/views/Header/HeaderBackButton.js
@@ -123,10 +123,10 @@ class HeaderBackButton extends React.PureComponent {
       </TouchableItem>
     );
 
-    if (Platform.OS === 'android') {
-      return <View style={styles.androidButtonWrapper}>{button}</View>;
-    } else {
+    if (Platform.OS === 'ios') {
       return button;
+    } else {
+      return <View style={styles.androidButtonWrapper}>{button}</View>;
     }
   }
 }

--- a/src/views/Header/HeaderTitle.js
+++ b/src/views/Header/HeaderTitle.js
@@ -14,8 +14,16 @@ const HeaderTitle = ({ style, ...rest }) => (
 
 const styles = StyleSheet.create({
   title: {
-    fontSize: Platform.OS === 'ios' ? 17 : 20,
-    fontWeight: Platform.OS === 'ios' ? '600' : '500',
+    ...Platform.select({
+      ios: {
+        fontSize: 17,
+        fontWeight: '600',
+      },
+      default: {
+        fontSize: 20,
+        fontWeight: '500',
+      }
+    }),
     color: 'rgba(0, 0, 0, .9)',
     marginHorizontal: 16,
   },

--- a/src/views/StackView/StackViewCard.js
+++ b/src/views/StackView/StackViewCard.js
@@ -14,7 +14,7 @@ function getAccessibilityProps(isActive) {
       importantForAccessibility: isActive ? 'yes' : 'no-hide-descendants',
     };
   } else {
-    return null;
+    return {};
   }
 }
 

--- a/src/views/StackView/StackViewLayout.js
+++ b/src/views/StackView/StackViewLayout.js
@@ -664,7 +664,7 @@ class StackViewLayout extends React.Component {
     if (this.props.headerMode) {
       return this.props.headerMode;
     }
-    if (Platform.OS === 'android' || this.props.mode === 'modal') {
+    if (Platform.OS !== 'ios' || this.props.mode === 'modal') {
       return 'screen';
     }
     return 'float';
@@ -724,7 +724,7 @@ class StackViewLayout extends React.Component {
       }
     }
 
-    if (Platform.OS === 'android') {
+    if (Platform.OS !== 'ios') {
       return 'left';
     } else {
       return 'center';
@@ -734,7 +734,7 @@ class StackViewLayout extends React.Component {
   _getHeaderTransitionPreset() {
     // On Android or with header mode screen, we always just use in-place,
     // we ignore the option entirely (at least until we have other presets)
-    if (Platform.OS === 'android' || this._getHeaderMode() === 'screen') {
+    if (Platform.OS !== 'ios' || this._getHeaderMode() === 'screen') {
       return 'fade-in-place';
     }
 
@@ -763,7 +763,7 @@ class StackViewLayout extends React.Component {
     // Even when we align to center on Android, people should need to opt-in to
     // showing the back title
     const enabledByDefault = !(
-      layoutPreset === 'left' || Platform.OS === 'android'
+      layoutPreset === 'left' || Platform.OS !== 'ios'
     );
 
     return typeof headerBackTitleVisible === 'boolean'

--- a/src/views/StackView/StackViewTransitionConfigs.js
+++ b/src/views/StackView/StackViewTransitionConfigs.js
@@ -68,7 +68,7 @@ function defaultTransitionConfig(
   prevTransitionProps,
   isModal
 ) {
-  if (Platform.OS === 'android') {
+  if (Platform.OS !== 'ios') {
     // Use the default Android animation no matter if the screen is a modal.
     // Android doesn't have full-screen modals like iOS does, it has dialogs.
     if (


### PR DESCRIPTION
# Why

Fix how navigation works (by default) in preparation for Expo web.

# How

* Make styles default to Material (same as RNWeb)
* Fixed minor bug where Assets returned nothing -- this throws in error in when users attempt to preload assets
* Fixed minor bug where null objects were being spread
* Prevent the use of `createKeyboardAwareNavigator` on web

# Related

#74 
[RNGH Web Support](https://github.com/kmagiera/react-native-gesture-handler/pull/406)