### PR TITLE
Remove commonJS on web

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,8 @@
   "version": "1.0.10",
   "description": "Stack navigator component for React Navigation",
   "main": "dist/index.js",
+  "module": "src/index.js",
+  "sideEffects": false,
   "files": [
     "dist/",
     "src/",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.10",
   "description": "Stack navigator component for React Navigation",
   "main": "dist/index.js",
-  "module": "src/index.js",
+  "module": "src/index.web.js",
   "sideEffects": false,
   "files": [
     "dist/",

--- a/src/index.js
+++ b/src/index.js
@@ -1,63 +1,40 @@
-/* eslint-disable import/no-commonjs */
 import { Platform } from 'react-native';
+/**
+ * Navigators
+ */
+export {
+  default as createStackNavigator,
+} from './navigators/createStackNavigator';
 
-module.exports = {
-  /**
-   * Navigators
-   */
-  get createStackNavigator() {
-    return require('./navigators/createStackNavigator').default;
-  },
+export const Assets = Platform.select({
+  ios: [
+    require('./views/assets/back-icon.png'),
+    require('./views/assets/back-icon-mask.png'),
+  ],
+  default: [require('./views/assets/back-icon.png')],
+});
 
-  /**
-   * Views
-   */
-  get Assets() {
-    return Platform.select({
-      ios: [
-        require('./views/assets/back-icon.png'),
-        require('./views/assets/back-icon-mask.png'),
-      ],
-      default: [require('./views/assets/back-icon.png')],
-    });
-  },
-  get Header() {
-    return require('./views/Header/Header').default;
-  },
-  get HeaderBackButton() {
-    return require('./views/Header/HeaderBackButton').default;
-  },
-  get HeaderTitle() {
-    return require('./views/Header/HeaderTitle').default;
-  },
-  get HeaderStyleInterpolator() {
-    return require('./views/Header/HeaderStyleInterpolator').default;
-  },
-  get StackView() {
-    return require('./views/StackView/StackView').default;
-  },
-  get StackViewCard() {
-    return require('./views/StackView/StackViewCard').default;
-  },
-  get StackViewLayout() {
-    return require('./views/StackView/StackViewLayout').default;
-  },
-  get StackViewStyleInterpolator() {
-    return require('./views/StackView/StackViewStyleInterpolator').default;
-  },
-  get StackViewTransitionConfigs() {
-    return require('./views/StackView/StackViewTransitionConfigs').default;
-  },
-  get createPointerEventsContainer() {
-    return require('./views/StackView/createPointerEventsContainer').default;
-  },
-  get Transitioner() {
-    return require('./views/Transitioner').default;
-  },
-  get ScenesReducer() {
-    return require('./views/ScenesReducer').default;
-  },
-  get StackGestureContext() {
-    return require('./utils/StackGestureContext').default;
-  },
-};
+/**
+ * Views
+ */
+export { default as Header } from './views/Header/Header';
+export { default as HeaderBackButton } from './views/Header/HeaderBackButton';
+export { default as HeaderTitle } from './views/Header/HeaderTitle';
+export {
+  default as HeaderStyleInterpolator,
+} from './views/Header/HeaderStyleInterpolator';
+export { default as StackView } from './views/StackView/StackView';
+export { default as StackViewCard } from './views/StackView/StackViewCard';
+export { default as StackViewLayout } from './views/StackView/StackViewLayout';
+export {
+  default as StackViewStyleInterpolator,
+} from './views/StackView/StackViewStyleInterpolator';
+export {
+  default as StackViewTransitionConfigs,
+} from './views/StackView/StackViewTransitionConfigs';
+export {
+  default as createPointerEventsContainer,
+} from './views/StackView/createPointerEventsContainer';
+export { default as Transitioner } from './views/Transitioner';
+export { default as ScenesReducer } from './views/ScenesReducer';
+export { default as StackGestureContext } from './utils/StackGestureContext';

--- a/src/index.js
+++ b/src/index.js
@@ -1,40 +1,63 @@
+/* eslint-disable import/no-commonjs */
 import { Platform } from 'react-native';
-/**
- * Navigators
- */
-export {
-  default as createStackNavigator,
-} from './navigators/createStackNavigator';
 
-export const Assets = Platform.select({
-  ios: [
-    require('./views/assets/back-icon.png'),
-    require('./views/assets/back-icon-mask.png'),
-  ],
-  default: [require('./views/assets/back-icon.png')],
-});
+module.exports = {
+  /**
+   * Navigators
+   */
+  get createStackNavigator() {
+    return require('./navigators/createStackNavigator').default;
+  },
 
-/**
- * Views
- */
-export { default as Header } from './views/Header/Header';
-export { default as HeaderBackButton } from './views/Header/HeaderBackButton';
-export { default as HeaderTitle } from './views/Header/HeaderTitle';
-export {
-  default as HeaderStyleInterpolator,
-} from './views/Header/HeaderStyleInterpolator';
-export { default as StackView } from './views/StackView/StackView';
-export { default as StackViewCard } from './views/StackView/StackViewCard';
-export { default as StackViewLayout } from './views/StackView/StackViewLayout';
-export {
-  default as StackViewStyleInterpolator,
-} from './views/StackView/StackViewStyleInterpolator';
-export {
-  default as StackViewTransitionConfigs,
-} from './views/StackView/StackViewTransitionConfigs';
-export {
-  default as createPointerEventsContainer,
-} from './views/StackView/createPointerEventsContainer';
-export { default as Transitioner } from './views/Transitioner';
-export { default as ScenesReducer } from './views/ScenesReducer';
-export { default as StackGestureContext } from './utils/StackGestureContext';
+  /**
+   * Views
+   */
+  get Assets() {
+    return Platform.select({
+      ios: [
+        require('./views/assets/back-icon.png'),
+        require('./views/assets/back-icon-mask.png'),
+      ],
+      default: [require('./views/assets/back-icon.png')],
+    });
+  },
+  get Header() {
+    return require('./views/Header/Header').default;
+  },
+  get HeaderBackButton() {
+    return require('./views/Header/HeaderBackButton').default;
+  },
+  get HeaderTitle() {
+    return require('./views/Header/HeaderTitle').default;
+  },
+  get HeaderStyleInterpolator() {
+    return require('./views/Header/HeaderStyleInterpolator').default;
+  },
+  get StackView() {
+    return require('./views/StackView/StackView').default;
+  },
+  get StackViewCard() {
+    return require('./views/StackView/StackViewCard').default;
+  },
+  get StackViewLayout() {
+    return require('./views/StackView/StackViewLayout').default;
+  },
+  get StackViewStyleInterpolator() {
+    return require('./views/StackView/StackViewStyleInterpolator').default;
+  },
+  get StackViewTransitionConfigs() {
+    return require('./views/StackView/StackViewTransitionConfigs').default;
+  },
+  get createPointerEventsContainer() {
+    return require('./views/StackView/createPointerEventsContainer').default;
+  },
+  get Transitioner() {
+    return require('./views/Transitioner').default;
+  },
+  get ScenesReducer() {
+    return require('./views/ScenesReducer').default;
+  },
+  get StackGestureContext() {
+    return require('./utils/StackGestureContext').default;
+  },
+};

--- a/src/index.web.js
+++ b/src/index.web.js
@@ -1,0 +1,40 @@
+import { Platform } from 'react-native';
+/**
+ * Navigators
+ */
+export {
+  default as createStackNavigator,
+} from './navigators/createStackNavigator';
+
+export const Assets = Platform.select({
+  ios: [
+    require('./views/assets/back-icon.png'),
+    require('./views/assets/back-icon-mask.png'),
+  ],
+  default: [require('./views/assets/back-icon.png')],
+});
+
+/**
+ * Views
+ */
+export { default as Header } from './views/Header/Header';
+export { default as HeaderBackButton } from './views/Header/HeaderBackButton';
+export { default as HeaderTitle } from './views/Header/HeaderTitle';
+export {
+  default as HeaderStyleInterpolator,
+} from './views/Header/HeaderStyleInterpolator';
+export { default as StackView } from './views/StackView/StackView';
+export { default as StackViewCard } from './views/StackView/StackViewCard';
+export { default as StackViewLayout } from './views/StackView/StackViewLayout';
+export {
+  default as StackViewStyleInterpolator,
+} from './views/StackView/StackViewStyleInterpolator';
+export {
+  default as StackViewTransitionConfigs,
+} from './views/StackView/StackViewTransitionConfigs';
+export {
+  default as createPointerEventsContainer,
+} from './views/StackView/createPointerEventsContainer';
+export { default as Transitioner } from './views/Transitioner';
+export { default as ScenesReducer } from './views/ScenesReducer';
+export { default as StackGestureContext } from './utils/StackGestureContext';

--- a/src/views/Header/HeaderTitle.js
+++ b/src/views/Header/HeaderTitle.js
@@ -22,7 +22,7 @@ const styles = StyleSheet.create({
       default: {
         fontSize: 20,
         fontWeight: '500',
-      }
+      },
     }),
     color: 'rgba(0, 0, 0, .9)',
     marginHorizontal: 16,


### PR DESCRIPTION
This is the bare minimum needed to get stack navigator running in web. Seems like it will add some bloat to native though. If this is a concern, I can look at adding something like we did with ExpoLazy where a lazy loaded file is produced and used as the main path. Perhaps we could also just add it to the existing babel phase.

**Related react-navigation/react-navigation-core#45**

<img width="820" alt="Screen Shot 2019-03-09 at 1 31 31 AM" src="https://user-images.githubusercontent.com/9664363/54069324-fbe9fc80-420b-11e9-86fb-9136d2c8806a.png">

Related
* Should resolve styles by creating parity with existing native functionality: https://github.com/react-navigation/react-navigation/issues/4939
* No need to say this doesn't work on web after we make it work on web 😄  https://github.com/react-navigation/react-navigation-stack/issues/74
