### PR TITLE
Interrupting swipe back animation on Stack view layout

### DIFF
--- a/src/navigators/__tests__/NestedNavigator-test.js
+++ b/src/navigators/__tests__/NestedNavigator-test.js
@@ -26,7 +26,7 @@ NavNestedIndirect.prototype.componentDidCatch = null;
 SubNavigator.prototype.componentDidCatch = null;
 
 describe('Nested navigators', () => {
-  it('renders succesfully as direct child', () => {
+  it('render succesfully as direct child', () => {
     const NavApp = createAppContainer(NavNestedDirect);
     const rendered = renderer.create(<NavApp />).toJSON();
     expect(rendered).toMatchSnapshot();

--- a/src/navigators/__tests__/__snapshots__/NestedNavigator-test.js.snap
+++ b/src/navigators/__tests__/__snapshots__/NestedNavigator-test.js.snap
@@ -217,7 +217,7 @@ exports[`Nested navigators renders succesfully as direct child 1`] = `
                             >
                               <Text
                                 accessibilityTraits="header"
-                                allowFontScaling={true}
+                                allowFontScaling={false}
                                 numberOfLines={1}
                                 onLayout={[Function]}
                                 style={
@@ -320,7 +320,7 @@ exports[`Nested navigators renders succesfully as direct child 1`] = `
                 >
                   <Text
                     accessibilityTraits="header"
-                    allowFontScaling={true}
+                    allowFontScaling={false}
                     numberOfLines={1}
                     onLayout={[Function]}
                     style={

--- a/src/navigators/__tests__/__snapshots__/NestedNavigator-test.js.snap
+++ b/src/navigators/__tests__/__snapshots__/NestedNavigator-test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Nested navigators renders succesfully as direct child 1`] = `
+exports[`Nested navigators render succesfully as direct child 1`] = `
 <View
   onLayout={[Function]}
   style={

--- a/src/navigators/__tests__/__snapshots__/StackNavigator-test.js.snap
+++ b/src/navigators/__tests__/__snapshots__/StackNavigator-test.js.snap
@@ -150,7 +150,7 @@ exports[`StackNavigator applies correct values when headerRight is present 1`] =
                 >
                   <Text
                     accessibilityTraits="header"
-                    allowFontScaling={true}
+                    allowFontScaling={false}
                     numberOfLines={1}
                     onLayout={[Function]}
                     style={
@@ -343,7 +343,7 @@ exports[`StackNavigator renders successfully 1`] = `
                 >
                   <Text
                     accessibilityTraits="header"
-                    allowFontScaling={true}
+                    allowFontScaling={false}
                     numberOfLines={1}
                     onLayout={[Function]}
                     style={

--- a/src/views/StackView/StackViewLayout.js
+++ b/src/views/StackView/StackViewLayout.js
@@ -562,8 +562,6 @@ class StackViewLayout extends React.Component {
       transitionProps: { navigation, position, layout },
     } = this.props;
     const { index } = navigation.state;
-    const immediateIndex =
-      this._immediateIndex == null ? index : this._immediateIndex;
 
     // Calculate animate duration according to gesture speed and moved distance
     const distance = layout.width.__getValue();
@@ -585,17 +583,32 @@ class StackViewLayout extends React.Component {
     position.setValue(value);
     this.positionSwitch.setValue(1);
 
-    const shouldGoBackCriterion = gestureVelocity > 50 || value <= index - POSITION_THRESHOLD;
+    const shouldGoBackCriterion =
+      gestureVelocity > 50 || value <= index - POSITION_THRESHOLD;
 
     if (shouldGoBackCriterion && this.props.onActionBeforeSwipeBack) {
       this.props.onActionBeforeSwipeBack({
-        onContinue: () => this._navigateWithGesture(this.props.onGestureEnd, goBackDuration, true),
-        onCancel: () => this._navigateWithGesture(this.props.onGestureCanceled, resetDuration, false)
+        onContinue: () =>
+          this._navigateWithGesture(
+            this.props.onGestureEnd,
+            goBackDuration,
+            true
+          ),
+        onCancel: () =>
+          this._navigateWithGesture(
+            this.props.onGestureCanceled,
+            resetDuration,
+            false
+          ),
       });
     } else if (shouldGoBackCriterion) {
       this._navigateWithGesture(this.props.onGestureEnd, goBackDuration, true);
     } else {
-      this._navigateWithGesture(this.props.onGestureCanceled, resetDuration, false);
+      this._navigateWithGesture(
+        this.props.onGestureCanceled,
+        resetDuration,
+        false
+      );
     }
   }
 

--- a/src/views/StackView/StackViewLayout.js
+++ b/src/views/StackView/StackViewLayout.js
@@ -636,27 +636,34 @@ class StackViewLayout extends React.Component {
     position.setValue(value);
     this.positionSwitch.setValue(1);
 
-    // If the speed of the gesture release is significant, use that as the indication
-    // of intent
-    if (gestureVelocity < -50) {
-      this.props.onGestureCanceled && this.props.onGestureCanceled();
-      this._reset(immediateIndex, resetDuration);
-      return;
-    }
-    if (gestureVelocity > 50) {
-      this.props.onGestureEnd && this.props.onGestureEnd();
-      this._goBack(immediateIndex, goBackDuration);
-      return;
-    }
+    const shouldGoBackCriterion = gestureVelocity > 50 && value <= index - POSITION_THRESHOLD;
 
-    // Then filter based on the distance the screen was moved. Over a third of the way swiped,
-    // and the back will happen.
-    if (value <= index - POSITION_THRESHOLD) {
-      this.props.onGestureEnd && this.props.onGestureEnd();
-      this._goBack(immediateIndex, goBackDuration);
+    if (shouldGoBackCriterion && this.props.onActionBeforeSwipeBack) {
+      this.props.onActionBeforeSwipeBack({
+        onContinue: () => this._navigateWithGesture(this.props.onGestureEnd, goBackDuration, true),
+        onCancel: () => this._navigateWithGesture(this.props.onGestureCanceled, resetDuration, false)
+      });
+    } else if (shouldGoBackCriterion) {
+      this._navigateWithGesture(this.props.onGestureEnd, goBackDuration, true);
     } else {
-      this.props.onGestureCanceled && this.props.onGestureCanceled();
-      this._reset(immediateIndex, resetDuration);
+      this._navigateWithGesture(this.props.onGestureCanceled, resetDuration, false);
+    }
+  }
+
+  _getImmediateIndex() {
+    const { index } = this.props.transitionProps.navigation.state;
+    const immediateIndex =
+      this._immediateIndex == null ? index : this._immediateIndex;
+
+    return immediateIndex;
+  }
+
+  _navigateWithGesture(gestureAction, duration, isGoingBack) {
+    gestureAction && gestureAction();
+    if (isGoingBack) {
+      this._goBack(this._getImmediateIndex(), duration);
+    } else {
+      this._reset(this._getImmediateIndex(), duration);
     }
   }
 

--- a/src/views/StackView/StackViewLayout.js
+++ b/src/views/StackView/StackViewLayout.js
@@ -585,27 +585,34 @@ class StackViewLayout extends React.Component {
     position.setValue(value);
     this.positionSwitch.setValue(1);
 
-    // If the speed of the gesture release is significant, use that as the indication
-    // of intent
-    if (gestureVelocity < -50) {
-      this.props.onGestureCanceled && this.props.onGestureCanceled();
-      this._reset(immediateIndex, resetDuration);
-      return;
-    }
-    if (gestureVelocity > 50) {
-      this.props.onGestureEnd && this.props.onGestureEnd();
-      this._goBack(immediateIndex, goBackDuration);
-      return;
-    }
+    const shouldGoBackCriterion = gestureVelocity > 50 || value <= index - POSITION_THRESHOLD;
 
-    // Then filter based on the distance the screen was moved. Over a third of the way swiped,
-    // and the back will happen.
-    if (value <= index - POSITION_THRESHOLD) {
-      this.props.onGestureEnd && this.props.onGestureEnd();
-      this._goBack(immediateIndex, goBackDuration);
+    if (shouldGoBackCriterion && this.props.onActionBeforeSwipeBack) {
+      this.props.onActionBeforeSwipeBack({
+        onContinue: () => this._navigateWithGesture(this.props.onGestureEnd, goBackDuration, true),
+        onCancel: () => this._navigateWithGesture(this.props.onGestureCanceled, resetDuration, false)
+      });
+    } else if (shouldGoBackCriterion) {
+      this._navigateWithGesture(this.props.onGestureEnd, goBackDuration, true);
     } else {
-      this.props.onGestureCanceled && this.props.onGestureCanceled();
-      this._reset(immediateIndex, resetDuration);
+      this._navigateWithGesture(this.props.onGestureCanceled, resetDuration, false);
+    }
+  }
+
+  _getImmediateIndex() {
+    const { index } = this.props.transitionProps.navigation.state;
+    const immediateIndex =
+      this._immediateIndex == null ? index : this._immediateIndex;
+
+    return immediateIndex;
+  }
+
+  _navigateWithGesture(gestureAction, duration, isGoingBack) {
+    gestureAction && gestureAction();
+    if (isGoingBack) {
+      this._goBack(this._getImmediateIndex(), duration);
+    } else {
+      this._reset(this._getImmediateIndex(), duration);
     }
   }
 
@@ -636,34 +643,27 @@ class StackViewLayout extends React.Component {
     position.setValue(value);
     this.positionSwitch.setValue(1);
 
-    const shouldGoBackCriterion = gestureVelocity > 50 && value <= index - POSITION_THRESHOLD;
-
-    if (shouldGoBackCriterion && this.props.onActionBeforeSwipeBack) {
-      this.props.onActionBeforeSwipeBack({
-        onContinue: () => this._navigateWithGesture(this.props.onGestureEnd, goBackDuration, true),
-        onCancel: () => this._navigateWithGesture(this.props.onGestureCanceled, resetDuration, false)
-      });
-    } else if (shouldGoBackCriterion) {
-      this._navigateWithGesture(this.props.onGestureEnd, goBackDuration, true);
-    } else {
-      this._navigateWithGesture(this.props.onGestureCanceled, resetDuration, false);
+    // If the speed of the gesture release is significant, use that as the indication
+    // of intent
+    if (gestureVelocity < -50) {
+      this.props.onGestureCanceled && this.props.onGestureCanceled();
+      this._reset(immediateIndex, resetDuration);
+      return;
     }
-  }
+    if (gestureVelocity > 50) {
+      this.props.onGestureEnd && this.props.onGestureEnd();
+      this._goBack(immediateIndex, goBackDuration);
+      return;
+    }
 
-  _getImmediateIndex() {
-    const { index } = this.props.transitionProps.navigation.state;
-    const immediateIndex =
-      this._immediateIndex == null ? index : this._immediateIndex;
-
-    return immediateIndex;
-  }
-
-  _navigateWithGesture(gestureAction, duration, isGoingBack) {
-    gestureAction && gestureAction();
-    if (isGoingBack) {
-      this._goBack(this._getImmediateIndex(), duration);
+    // Then filter based on the distance the screen was moved. Over a third of the way swiped,
+    // and the back will happen.
+    if (value <= index - POSITION_THRESHOLD) {
+      this.props.onGestureEnd && this.props.onGestureEnd();
+      this._goBack(immediateIndex, goBackDuration);
     } else {
-      this._reset(this._getImmediateIndex(), duration);
+      this.props.onGestureCanceled && this.props.onGestureCanceled();
+      this._reset(immediateIndex, resetDuration);
     }
   }
 


### PR DESCRIPTION
# Motivation
Being able to detect and interrupt swipe back animation on Stack navigator

# Change
Adding `onActionBeforeSwipeBack` in navigation config, with the following object:
```
{ onContinue:() => void, onCancel: () => void }
```
where `onContinue()` will continue the swipe back animation and `onCancel()` will reset back to the original screen.

# Example gif
![swipe](https://user-images.githubusercontent.com/11971101/55388101-8827d080-54e7-11e9-9702-159dc0bb706e.gif)

# Example code snippet
You can view it [here](https://gist.github.com/hoangpham95/fbafbf78ac697428321321ba81b2c718)