### PR TITLE
[web] Updated header style for web

### DIFF
--- a/src/index.web.js
+++ b/src/index.web.js
@@ -1,4 +1,3 @@
-import { Platform } from 'react-native';
 /**
  * Navigators
  */
@@ -6,13 +5,7 @@ export {
   default as createStackNavigator,
 } from './navigators/createStackNavigator';
 
-export const Assets = Platform.select({
-  ios: [
-    require('./views/assets/back-icon.png'),
-    require('./views/assets/back-icon-mask.png'),
-  ],
-  default: [require('./views/assets/back-icon.png')],
-});
+export const Assets = [];
 
 /**
  * Views

--- a/src/views/Header/BackButton.web.js
+++ b/src/views/Header/BackButton.web.js
@@ -1,0 +1,10 @@
+import React from 'react';
+
+export default ({ tintColor }) => (
+  <svg width="24px" height="24px" viewBox="0 0 24 24">
+    <path
+      fill={tintColor}
+      d="M20 11H7.83l5.59-5.59L12 4l-8 8 8 8 1.41-1.41L7.83 13H20v-2z"
+    />
+  </svg>
+);

--- a/src/views/Header/Header.js
+++ b/src/views/Header/Header.js
@@ -35,7 +35,8 @@ const TITLE_OFFSET_CENTER_ALIGN = Platform.select({
 
 const TITLE_OFFSET_LEFT_ALIGN = Platform.select({
   ios: 20,
-  default: 56,
+  android: 56,
+  default: 64,
 });
 
 const getTitleOffsets = (
@@ -54,7 +55,7 @@ const getTitleOffsets = (
     };
 
     if (!hasLeftComponent) {
-      style.left = Platform.OS === 'web' ? 8 : 0;
+      style.left = Platform.OS === 'web' ? 16 : 0;
     }
     if (!hasRightComponent) {
       style.right = 0;
@@ -696,10 +697,6 @@ const styles = StyleSheet.create({
   header: {
     ...StyleSheet.absoluteFillObject,
     flexDirection: 'row',
-    ...Platform.select({
-      default: {},
-      web: { marginHorizontal: 8 },
-    }),
   },
   item: {
     backgroundColor: 'transparent',

--- a/src/views/Header/Header.js
+++ b/src/views/Header/Header.js
@@ -54,7 +54,7 @@ const getTitleOffsets = (
     };
 
     if (!hasLeftComponent) {
-      style.left = 0;
+      style.left = Platform.OS === 'web' ? 8 : 0;
     }
     if (!hasRightComponent) {
       style.right = 0;
@@ -698,7 +698,7 @@ const styles = StyleSheet.create({
     flexDirection: 'row',
     ...Platform.select({
       default: {},
-      web: { marginHorizontal: 16 },
+      web: { marginHorizontal: 8 },
     }),
   },
   item: {

--- a/src/views/Header/Header.js
+++ b/src/views/Header/Header.js
@@ -17,12 +17,26 @@ import HeaderBackButton from './HeaderBackButton';
 import ModularHeaderBackButton from './ModularHeaderBackButton';
 import HeaderStyleInterpolator from './HeaderStyleInterpolator';
 
-const APPBAR_HEIGHT = Platform.OS === 'ios' ? 44 : 56;
-const STATUSBAR_HEIGHT = Platform.OS === 'ios' ? 20 : 0;
+const APPBAR_HEIGHT = Platform.select({
+  ios: 44,
+  android: 56,
+  default: 64,
+});
+const STATUSBAR_HEIGHT = Platform.select({
+  ios: 20,
+  default: 0,
+});
 
 // These can be adjusted by using headerTitleContainerStyle on navigationOptions
-const TITLE_OFFSET_CENTER_ALIGN = Platform.OS === 'ios' ? 70 : 56;
-const TITLE_OFFSET_LEFT_ALIGN = Platform.OS === 'ios' ? 20 : 56;
+const TITLE_OFFSET_CENTER_ALIGN = Platform.select({
+  ios: 70,
+  default: 56,
+});
+
+const TITLE_OFFSET_LEFT_ALIGN = Platform.select({
+  ios: 20,
+  default: 56,
+});
 
 const getTitleOffsets = (
   layoutPreset,
@@ -62,11 +76,17 @@ const getTitleOffsets = (
 };
 
 const getAppBarHeight = isLandscape => {
-  return Platform.OS === 'ios'
-    ? isLandscape && !Platform.isPad
-      ? 32
-      : 44
-    : 56;
+  if (Platform.OS === 'ios') {
+    if (isLandscape && !Platform.isPad) {
+      return 32;
+    } else {
+      return 44;
+    }
+  } else if (Platform.OS === 'android') {
+    return 56;
+  } else {
+    return 64;
+  }
 };
 
 class Header extends React.PureComponent {
@@ -676,6 +696,10 @@ const styles = StyleSheet.create({
   header: {
     ...StyleSheet.absoluteFillObject,
     flexDirection: 'row',
+    ...Platform.select({
+      default: {},
+      web: { marginHorizontal: 16 },
+    }),
   },
   item: {
     backgroundColor: 'transparent',

--- a/src/views/Header/HeaderBackButton.js
+++ b/src/views/Header/HeaderBackButton.js
@@ -148,6 +148,7 @@ const styles = StyleSheet.create({
   },
   androidButtonWrapper: {
     margin: 13,
+    marginLeft: Platform.OS === 'web' && 8 + 13,
     backgroundColor: 'transparent',
   },
   container: {
@@ -159,26 +160,26 @@ const styles = StyleSheet.create({
     fontSize: 17,
     paddingRight: 10,
   },
-  icon:
-    Platform.OS === 'ios'
-      ? {
-          backgroundColor: 'transparent',
-          height: 21,
-          width: 13,
-          marginLeft: 9,
-          marginRight: 22,
-          marginVertical: 12,
-          resizeMode: 'contain',
-          transform: [{ scaleX: I18nManager.isRTL ? -1 : 1 }],
-        }
-      : {
-          height: 24,
-          width: 24,
-          margin: 3,
-          resizeMode: 'contain',
-          backgroundColor: 'transparent',
-          transform: [{ scaleX: I18nManager.isRTL ? -1 : 1 }],
-        },
+  icon: Platform.select({
+    ios: {
+      backgroundColor: 'transparent',
+      height: 21,
+      width: 13,
+      marginLeft: 9,
+      marginRight: 22,
+      marginVertical: 12,
+      resizeMode: 'contain',
+      transform: [{ scaleX: I18nManager.isRTL ? -1 : 1 }],
+    },
+    default: {
+      height: 24,
+      width: 24,
+      margin: 3,
+      resizeMode: 'contain',
+      backgroundColor: 'transparent',
+      transform: [{ scaleX: I18nManager.isRTL ? -1 : 1 }],
+    },
+  }),
   iconWithTitle:
     Platform.OS === 'ios'
       ? {

--- a/src/views/Header/HeaderBackButton.js
+++ b/src/views/Header/HeaderBackButton.js
@@ -148,8 +148,13 @@ const styles = StyleSheet.create({
   },
   androidButtonWrapper: {
     margin: 13,
-    marginLeft: Platform.OS === 'web' && 8 + 13,
     backgroundColor: 'transparent',
+    ...Platform.select({
+      web: {
+        marginLeft: 21,
+      },
+      default: {},
+    }),
   },
   container: {
     alignItems: 'center',

--- a/src/views/Header/HeaderBackButton.js
+++ b/src/views/Header/HeaderBackButton.js
@@ -11,14 +11,19 @@ import {
 import TouchableItem from '../TouchableItem';
 
 import defaultBackImage from '../assets/back-icon.png';
+import BackButtonWeb from './BackButton.web';
 
 class HeaderBackButton extends React.PureComponent {
   static defaultProps = {
     pressColorAndroid: 'rgba(0, 0, 0, .32)',
     tintColor: Platform.select({
       ios: '#037aff',
+      web: '#5f6368',
     }),
     truncatedTitle: 'Back',
+    backImage: Platform.select({
+      web: BackButtonWeb,
+    }),
   };
 
   state = {};

--- a/src/views/Header/HeaderTitle.js
+++ b/src/views/Header/HeaderTitle.js
@@ -18,14 +18,21 @@ const styles = StyleSheet.create({
       ios: {
         fontSize: 17,
         fontWeight: '600',
+        color: 'rgba(0, 0, 0, .9)',
+        marginHorizontal: 16,
       },
-      default: {
+      android: {
         fontSize: 20,
         fontWeight: '500',
+        color: 'rgba(0, 0, 0, .9)',
+        marginHorizontal: 16,
+      },
+      default: {
+        fontSize: 18,
+        fontWeight: '400',
+        color: '#3c4043',
       },
     }),
-    color: 'rgba(0, 0, 0, .9)',
-    marginHorizontal: 16,
   },
 });
 

--- a/src/views/StackView/StackViewLayout.js
+++ b/src/views/StackView/StackViewLayout.js
@@ -78,8 +78,10 @@ const getDefaultHeaderHeight = isLandscape => {
     } else {
       return 64;
     }
-  } else {
+  } else if (Platform.OS === 'android') {
     return 56;
+  } else {
+    return 64;
   }
 };
 


### PR DESCRIPTION
* Using material SVG for back button due to safari image tint bug https://github.com/necolas/react-native-web/issues/1319
* Updated header bar height to be 64px
* Updated header title style to match material color, size, weight
* Changed how header margins work on web
* Removed assets on web

# Default 

![Screen Shot 2019-04-10 at 4 13 49 PM](https://user-images.githubusercontent.com/9664363/55919666-b07c9280-5bab-11e9-9b4d-c33a5c0985e5.png)
![Screen Shot 2019-04-10 at 4 13 53 PM](https://user-images.githubusercontent.com/9664363/55919667-b07c9280-5bab-11e9-9b4e-274f58b59b5a.png)

# Custom 

![Screen Shot 2019-04-10 at 4 13 20 PM](https://user-images.githubusercontent.com/9664363/55919663-afe3fc00-5bab-11e9-8ab1-2cee8f0061a9.png)
![Screen Shot 2019-04-10 at 4 13 26 PM](https://user-images.githubusercontent.com/9664363/55919664-afe3fc00-5bab-11e9-9d99-6caeac203cfb.png)
