### PR TITLE
[web] Sticky Header

### DIFF
--- a/src/views/StackView/StackViewCard.js
+++ b/src/views/StackView/StackViewCard.js
@@ -57,7 +57,7 @@ class Card extends React.Component {
       <Screen
         pointerEvents={pointerEvents}
         onComponentRef={this.props.onComponentRef}
-        style={[StyleSheet.absoluteFill, containerAnimatedStyle, screenStyle]}
+        style={[containerAnimatedStyle, screenStyle]}
         active={active}
       >
         {!transparent && shadowOpacity ? (

--- a/src/views/StackView/StackViewLayout.js
+++ b/src/views/StackView/StackViewLayout.js
@@ -851,9 +851,12 @@ class StackViewLayout extends React.Component {
     const { options } = scene.descriptor;
     const hasHeader = options.header !== null;
     const headerMode = this._getHeaderMode();
-    let paddingTopStyle;
+    let floatingContainerStyle = StyleSheet.absoluteFill;
     if (hasHeader && headerMode === 'float' && !options.headerTransparent) {
-      paddingTopStyle = { paddingTop: this.state.floatingHeaderHeight };
+      floatingContainerStyle = {
+        ...Platform.select({ web: {}, default: StyleSheet.absoluteFillObject }),
+        paddingTop: this.state.floatingHeaderHeight,
+      };
     }
 
     return (
@@ -864,7 +867,7 @@ class StackViewLayout extends React.Component {
         realPosition={transitionProps.position}
         animatedStyle={style}
         transparent={transparentCard}
-        style={[paddingTopStyle, cardStyle]}
+        style={[floatingContainerStyle, cardStyle]}
         scene={scene}
       >
         {this._renderInnerScene(scene)}
@@ -887,7 +890,7 @@ const styles = StyleSheet.create({
     flex: 1,
   },
   floatingHeader: {
-    position: 'absolute',
+    position: Platform.select({ default: 'absolute', web: 'fixed' }),
     left: 0,
     top: 0,
     right: 0,


### PR DESCRIPTION

# Why

In mobile Safari the header should collapse when content is scrolled. This will enable that functionality when header mode is set to `float`.

# How

* Enabled body scrolling on web by preventing cards from clipping the scrollview.
* Relies on https://github.com/kmagiera/react-native-screens/pull/88/files