### PR TITLE
[iOS][Android] Prevent transitionConfig's useNativeDriver value being overwritten.

### DIFF
--- a/src/views/StackView/StackView.js
+++ b/src/views/StackView/StackView.js
@@ -47,13 +47,13 @@ class StackView extends React.Component {
 
   _configureTransition = (transitionProps, prevTransitionProps) => {
     return {
+      useNativeDriver: USE_NATIVE_DRIVER,
       ...TransitionConfigs.getTransitionConfig(
         this.props.navigationConfig.transitionConfig,
         transitionProps,
         prevTransitionProps,
         this.props.navigationConfig.mode === 'modal'
       ).transitionSpec,
-      useNativeDriver: USE_NATIVE_DRIVER,
     };
   };
 


### PR DESCRIPTION
### Why
When using a custom transitionConfig to describe transition animations, its `useNativeDriver` value is ignored by the stack view. This change ensures that the stack view will honour the value from the transitionConfig.

### How
I just changed the order of the properties in `_configureTransition`, so it will return the default `USE_NATIVE_DRIVER` value if the user does not override it.